### PR TITLE
Correct github/linguist issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*/*.nc linguist-generated=true


### PR DESCRIPTION
Various .nc files incorrectly identified as nesC language by github/linguist.
Use .gitattributes file to override detection by markiing the file as 'generated code'.